### PR TITLE
Allows arbitrary loads in app transport security

### DIFF
--- a/HackerNewsReader/Info.plist
+++ b/HackerNewsReader/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
This is a fix for iOS 9 where `http` links fail to load

![error](https://cloud.githubusercontent.com/assets/4723115/10580530/b9bd300a-7632-11e5-840a-cd5fb7272a0e.png)
![fix](https://cloud.githubusercontent.com/assets/4723115/10580496/9d5daf7a-7632-11e5-8200-e278c7d9d6ed.png)
