### PR TITLE
Mark post as read when viewing comments

### DIFF
--- a/HackerNewsReader/Classes/HNFeedViewController.m
+++ b/HackerNewsReader/Classes/HNFeedViewController.m
@@ -176,6 +176,10 @@ static NSUInteger const kItemsPerPage = 30;
     NSIndexPath *indexPath = [self.tableView indexPathForCell:postCell];
     if (indexPath) {
         HNPost *post = self.feedDataSource.posts[indexPath.row];
+        
+        [self.readPostStore readPK:post.pk];
+        [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+        
         HNCommentViewController *commentController = [[HNCommentViewController alloc] initWithPostID:post.pk];
         [self hn_showDetailViewControllerWithFallback:commentController];
     }


### PR DESCRIPTION
This is for a different reading flow when the headline is clear and reading the comments is the primary action..