### PR TITLE
HNR: Episode III - Revenge of the Parse

### DIFF
--- a/Frameworks/HackerNewsNetworker/Pod/Assets/fallback-queries.json
+++ b/Frameworks/HackerNewsNetworker/Pod/Assets/fallback-queries.json
@@ -1,12 +1,12 @@
 {
   "feed": {
-    "titles": "//table[@id='hnmain']/tr[3]/td/table//td[@class='title'][not(@align)]/a",
-    "details": "//table[@id='hnmain']/tr[3]/td/table//td[@class='subtext']",
+    "titles": "//table[@id='hnmain']/tr[4]/td/table//td[@class='title'][not(@align)]/a",
+    "details": "//table[@id='hnmain']/tr[4]/td/table//td[@class='subtext']",
     "score": "//span[@class='score']",
     "comment_node": "(//a)[last()]"
   },
   "comments": {
-    "comments": "//table[@id='hnmain']/tr[3]/td/table[2]/tr",
+    "comments": "//table[@id='hnmain']/tr[4]/td/table[2]/tr",
     "user": "//span[@class='comhead']/a[1]",
     "text": "//span[@class='comment']/span",
     "removed": "//span[@class='comment']",
@@ -14,12 +14,12 @@
     "permalink": "//span[@class='age']/a"
   },
   "page": {
-    "text": "//table[@id='hnmain']/tr[3]/td/table[1]/tr[4]/td[2]"
+    "text": "//table[@id='hnmain']/tr[4]/td/table[1]/tr[4]/td[2]"
   },
   "user": {
-    "username": "//table[@id='hnmain']/tr[3]/td//table//tr[1]/td[2]/a",
-    "created": "//table[@id='hnmain']/tr[3]/td//table//tr[2]/td[2]",
-    "karma": "//table[@id='hnmain']/tr[3]/td//table//tr[3]/td[2]",
-    "about": "//table[@id='hnmain']/tr[3]/td//table//tr[4]/td[2]",
+    "username": "//table[@id='hnmain']/tr[4]/td//table//tr[1]/td[2]/a",
+    "created": "//table[@id='hnmain']/tr[4]/td//table//tr[2]/td[2]",
+    "karma": "//table[@id='hnmain']/tr[4]/td//table//tr[3]/td[2]",
+    "about": "//table[@id='hnmain']/tr[4]/td//table//tr[4]/td[2]",
   }
 }

--- a/Frameworks/HackerNewsNetworker/Pod/Classes/HNPageParser.m
+++ b/Frameworks/HackerNewsNetworker/Pod/Classes/HNPageParser.m
@@ -40,7 +40,7 @@
 
     NSArray *comments = (NSArray *)[self.commentParser commentsFromParser:parser queries:queries];
 
-    static NSString * const textQuery = @"//table[@id='hnmain']/tr[3]/td/table[1]/tr[4]/td[2]";
+    static NSString * const textQuery = @"//table[@id='hnmain']/tr[4]/td/table[1]/tr[4]/td[2]";
     TFHppleElement *textNode = [[parser searchWithXPathQuery:textQuery] firstObject];
     NSArray *textComponets = nil;
     if ([[textNode content] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]].length) {


### PR DESCRIPTION


### This fixes #13

Looks like an update to Hacker News' HTML broke the app's parsing. One single addition of a `<tr>` was the culprit.

I'd also recommend updating http://whoisryannystrom.com/hackernews.json:

```json
{
  "feed": {
    "titles": "//table[@id='hnmain']/tr[4]/td/table//td[@class='title'][not(@align)]/a",
    "details": "//table[@id='hnmain']/tr[4]/td/table//td[@class='subtext']",
    "score": "//span[@class='score']",
    "comment_node": "(//a)[last()]"
  },
  "comments": {
    "comments": "//table[@id='hnmain']/tr[4]/td/table[2]/tr",
    "user": "//span[@class='comhead']/a[1]",
    "text": "//span[@class='comment']/span",
    "removed": "//span[@class='comment']",
    "indent": "//img[@src='s.gif']",
    "permalink": "//span[@class='age']/a"
  },
  "page": {
    "text": "//table[@id='hnmain']/tr[4]/td/table[1]/tr[4]/td[2]"
  },
  "user": {
    "username": "//table[@id='hnmain']/tr[4]/td//table//tr[1]/td[2]/a",
    "created": "//table[@id='hnmain']/tr[4]/td//table//tr[2]/td[2]",
    "karma": "//table[@id='hnmain']/tr[4]/td//table//tr[3]/td[2]",
    "about": "//table[@id='hnmain']/tr[4]/td//table//tr[4]/td[2]",
  }
}

```