### PR TITLE
Replace UISearchDisplayController with UISearchController

### DIFF
--- a/HackerNewsReader.xcodeproj/project.pbxproj
+++ b/HackerNewsReader.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		29EA87DE1DD7AC9200B6F84A /* libxml2.2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 29EA87DD1DD7AC9200B6F84A /* libxml2.2.tbd */; };
 		29EA87E51DD7ACFC00B6F84A /* NSURL+HackerNewsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 29EA87E11DD7ACF300B6F84A /* NSURL+HackerNewsTests.m */; };
 		58FBF42904A3BAC63095A11D /* Pods_HackerNewsReader.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11E97AC09D67B152186BF4B6 /* Pods_HackerNewsReader.framework */; };
+		75642A102002D3F6003AC045 /* NHResultsController.m in Sources */ = {isa = PBXBuildFile; fileRef = 75642A0F2002D3F6003AC045 /* NHResultsController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -243,6 +244,8 @@
 		29EA87DD1DD7AC9200B6F84A /* libxml2.2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libxml2.2.tbd; path = usr/lib/libxml2.2.tbd; sourceTree = SDKROOT; };
 		29EA87E01DD7ACF300B6F84A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		29EA87E11DD7ACF300B6F84A /* NSURL+HackerNewsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+HackerNewsTests.m"; sourceTree = "<group>"; };
+		75642A0E2002D3F6003AC045 /* NHResultsController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NHResultsController.h; sourceTree = "<group>"; };
+		75642A0F2002D3F6003AC045 /* NHResultsController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NHResultsController.m; sourceTree = "<group>"; };
 		D231C5C33344FF1151733EC4 /* Pods-HackerNewsReader.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HackerNewsReader.release.xcconfig"; path = "Pods/Target Support Files/Pods-HackerNewsReader/Pods-HackerNewsReader.release.xcconfig"; sourceTree = "<group>"; };
 		D8AA24FB5C8D7138D6A5225A /* Pods-HackerNewsReader.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HackerNewsReader.debug.xcconfig"; path = "Pods/Target Support Files/Pods-HackerNewsReader/Pods-HackerNewsReader.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -476,6 +479,8 @@
 				29EA876F1DD7AAAA00B6F84A /* HNProfileViewController.m */,
 				29EA87701DD7AAAA00B6F84A /* HNSearchPostsController.h */,
 				29EA87711DD7AAAA00B6F84A /* HNSearchPostsController.m */,
+				75642A0E2002D3F6003AC045 /* NHResultsController.h */,
+				75642A0F2002D3F6003AC045 /* NHResultsController.m */,
 				29EA87721DD7AAAA00B6F84A /* HNSplitViewDelegate.h */,
 				29EA87731DD7AAAA00B6F84A /* HNSplitViewDelegate.m */,
 				29EA87741DD7AAAA00B6F84A /* HNSubmissionsViewController.h */,
@@ -794,6 +799,7 @@
 				29EA879C1DD7AAAA00B6F84A /* HNCommentComponent.m in Sources */,
 				29EA87991DD7AAAA00B6F84A /* UIViewController+Storyboards.m in Sources */,
 				29EA87BA1DD7AAAA00B6F84A /* HNFeedViewController.m in Sources */,
+				75642A102002D3F6003AC045 /* NHResultsController.m in Sources */,
 				29EA879E1DD7AAAA00B6F84A /* HNPage.m in Sources */,
 				29EA87C61DD7AAAA00B6F84A /* HNCommentCell.m in Sources */,
 				29EA87C11DD7AAAA00B6F84A /* HNSubmissionsViewController.m in Sources */,

--- a/HackerNewsReader.xcodeproj/project.pbxproj
+++ b/HackerNewsReader.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		29EA87DE1DD7AC9200B6F84A /* libxml2.2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 29EA87DD1DD7AC9200B6F84A /* libxml2.2.tbd */; };
 		29EA87E51DD7ACFC00B6F84A /* NSURL+HackerNewsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 29EA87E11DD7ACF300B6F84A /* NSURL+HackerNewsTests.m */; };
 		58FBF42904A3BAC63095A11D /* Pods_HackerNewsReader.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11E97AC09D67B152186BF4B6 /* Pods_HackerNewsReader.framework */; };
+		7556A2AE200387B60097841F /* UIBarButtonItem+HackerNews.m in Sources */ = {isa = PBXBuildFile; fileRef = 7556A2AD200387B60097841F /* UIBarButtonItem+HackerNews.m */; };
 		75642A102002D3F6003AC045 /* NHResultsController.m in Sources */ = {isa = PBXBuildFile; fileRef = 75642A0F2002D3F6003AC045 /* NHResultsController.m */; };
 /* End PBXBuildFile section */
 
@@ -244,6 +245,8 @@
 		29EA87DD1DD7AC9200B6F84A /* libxml2.2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libxml2.2.tbd; path = usr/lib/libxml2.2.tbd; sourceTree = SDKROOT; };
 		29EA87E01DD7ACF300B6F84A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		29EA87E11DD7ACF300B6F84A /* NSURL+HackerNewsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+HackerNewsTests.m"; sourceTree = "<group>"; };
+		7556A2AC200387B60097841F /* UIBarButtonItem+HackerNews.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIBarButtonItem+HackerNews.h"; sourceTree = "<group>"; };
+		7556A2AD200387B60097841F /* UIBarButtonItem+HackerNews.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIBarButtonItem+HackerNews.m"; sourceTree = "<group>"; };
 		75642A0E2002D3F6003AC045 /* NHResultsController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NHResultsController.h; sourceTree = "<group>"; };
 		75642A0F2002D3F6003AC045 /* NHResultsController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NHResultsController.m; sourceTree = "<group>"; };
 		D231C5C33344FF1151733EC4 /* Pods-HackerNewsReader.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HackerNewsReader.release.xcconfig"; path = "Pods/Target Support Files/Pods-HackerNewsReader/Pods-HackerNewsReader.release.xcconfig"; sourceTree = "<group>"; };
@@ -336,6 +339,8 @@
 				29EA870A1DD7AAAA00B6F84A /* UIFont+HackerNews.m */,
 				29EA870B1DD7AAAA00B6F84A /* UINavigationBar+HackerNews.h */,
 				29EA870C1DD7AAAA00B6F84A /* UINavigationBar+HackerNews.m */,
+				7556A2AC200387B60097841F /* UIBarButtonItem+HackerNews.h */,
+				7556A2AD200387B60097841F /* UIBarButtonItem+HackerNews.m */,
 				29EA870D1DD7AAAA00B6F84A /* UINavigationController+HNBarState.h */,
 				29EA870E1DD7AAAA00B6F84A /* UINavigationController+HNBarState.m */,
 				29EA870F1DD7AAAA00B6F84A /* UITabBar+HackerNews.h */,
@@ -789,6 +794,7 @@
 				29EA879F1DD7AAAA00B6F84A /* HNPost.m in Sources */,
 				29EA87B31DD7AAAA00B6F84A /* HNReadPostStore.m in Sources */,
 				29EA87A01DD7AAAA00B6F84A /* HNUser.m in Sources */,
+				7556A2AE200387B60097841F /* UIBarButtonItem+HackerNews.m in Sources */,
 				29EA87CA1DD7AAAA00B6F84A /* HNPageHeaderView.m in Sources */,
 				29EA87CB1DD7AAAA00B6F84A /* HNPostCell.m in Sources */,
 				29EA87AB1DD7AAAA00B6F84A /* HNSessionManager.m in Sources */,

--- a/HackerNewsReader/Classes/AppDelegate.m
+++ b/HackerNewsReader/Classes/AppDelegate.m
@@ -17,6 +17,7 @@
 #import "UIToolbar+HackerNews.h"
 #import "UITabBar+HackerNews.h"
 #import "UINavigationBar+HackerNews.h"
+#import "UIBarButtonItem+HackerNews.h"
 #import "HNSessionManager.h"
 
 NSString * const kHNAppDelegateDidTapStatusBar = @"kHNAppDelegateDidTapStatusBar";
@@ -41,6 +42,7 @@ NSString * const kHNAppDelegateDidTapStatusBar = @"kHNAppDelegateDidTapStatusBar
     [UINavigationBar hn_enableAppearance];
     [UIToolbar hn_enableAppearance];
     [UITabBar hn_enableAppearance];
+    [UIBarButtonItem hn_enableAppearance];
 
 //    UISplitViewController *rootViewController = (UISplitViewController *)self.window.rootViewController;
 //    UITabBarController *tabBarController = rootViewController.viewControllers.firstObject;

--- a/HackerNewsReader/Classes/Categories/UIBarButtonItem+HackerNews.h
+++ b/HackerNewsReader/Classes/Categories/UIBarButtonItem+HackerNews.h
@@ -1,0 +1,19 @@
+//
+//  UIBarButtonItem+HackerNews.h
+//  HackerNewsReader
+//
+//  Created by Ivan Magda on 08/01/2018.
+//  Copyright © 2018 Ryan Nystrom. All rights reserved.
+//
+
+@import UIKit;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UIBarButtonItem (HackerNews)
+
++ (void)hn_enableAppearance;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/HackerNewsReader/Classes/Categories/UIBarButtonItem+HackerNews.m
+++ b/HackerNewsReader/Classes/Categories/UIBarButtonItem+HackerNews.m
@@ -1,0 +1,22 @@
+//
+//  UIBarButtonItem+HackerNews.m
+//  HackerNewsReader
+//
+//  Created by Ivan Magda on 08/01/2018.
+//  Copyright © 2018 Ryan Nystrom. All rights reserved.
+//
+
+#import "UIBarButtonItem+HackerNews.h"
+
+#import "UIColor+HackerNews.h"
+
+@implementation UIBarButtonItem (HackerNews)
+
++ (void)hn_enableAppearance {
+    if (@available(iOS 11.0, *)) {
+        id appearance = [self appearanceWhenContainedInInstancesOfClasses:@[UISearchBar.class]];
+        [appearance setTintColor:[UIColor hn_navigationTintColor]];
+    }
+}
+
+@end

--- a/HackerNewsReader/Classes/ViewControllers/HNSearchPostsController.h
+++ b/HackerNewsReader/Classes/ViewControllers/HNSearchPostsController.h
@@ -10,14 +10,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class HNPost, HNReadPostStore;
+@class HNReadPostStore;
 
-@interface HNSearchPostsController : UISearchDisplayController
+@interface HNSearchPostsController : UISearchController
 
-- (instancetype)initWithContentsController:(UIViewController *)viewController
-                             readPostStore:(HNReadPostStore *)readPostStore NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithOriginalController:(UIViewController *)viewController
+                          andReadPostStore:(HNReadPostStore *)readPostStore NS_DESIGNATED_INITIALIZER;
 
-@property (nonatomic, copy) NSArray *posts;
+@property(nonatomic, copy) NSArray *posts;
 
 @end
 

--- a/HackerNewsReader/Classes/ViewControllers/NHResultsController.h
+++ b/HackerNewsReader/Classes/ViewControllers/NHResultsController.h
@@ -1,0 +1,26 @@
+//
+//  NHResultsController.h
+//  HackerNewsReader
+//
+//  Created by Ivan Magda on 08/01/2018.
+//  Copyright © 2018 Ryan Nystrom. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@class HNReadPostStore;
+
+@interface NHResultsController : UITableViewController
+
+- (instancetype)initWithStyle:(UITableViewStyle)style NS_UNAVAILABLE;
+
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
+
+- (instancetype)initWithOriginalController:(UIViewController *)viewController
+                          andReadPostStore:(HNReadPostStore *)readPostStore NS_DESIGNATED_INITIALIZER;
+
+- (void)setPosts:(NSArray *)posts;
+
+@end

--- a/HackerNewsReader/Classes/ViewControllers/NHResultsController.m
+++ b/HackerNewsReader/Classes/ViewControllers/NHResultsController.m
@@ -1,0 +1,111 @@
+//
+//  NHResultsController.m
+//  HackerNewsReader
+//
+//  Created by Ivan Magda on 08/01/2018.
+//  Copyright © 2018 Ryan Nystrom. All rights reserved.
+//
+
+#import "NHResultsController.h"
+
+#import "HNPost.h"
+
+#import "HNFeedDataSource.h"
+#import "HNReadPostStore.h"
+#import "HNPostCell.h"
+#import "HNPostControllerHandling.h"
+#import "UIViewController+UISplitViewController.h"
+#import "HNCommentViewController.h"
+
+@interface NHResultsController () <HNPostCellDelegate>
+
+- (instancetype)initWithStyle:(UITableViewStyle)style NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder NS_DESIGNATED_INITIALIZER;
+
+@property(nonatomic, strong) HNFeedDataSource *feedDataSource;
+@property(nonatomic, strong) HNReadPostStore *readPostStore;
+@property(nonatomic, weak) UIViewController *originalController;
+
+@end
+
+@implementation NHResultsController
+
+- (instancetype)initWithStyle:(UITableViewStyle)style {
+    @throw nil;
+}
+
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
+    @throw nil;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    @throw nil;
+}
+
+- (instancetype)initWithOriginalController:(UIViewController *)viewController andReadPostStore:(HNReadPostStore *)readPostStore {
+    if (self = [super initWithStyle:UITableViewStylePlain]) {
+        _originalController = viewController;
+        _readPostStore = readPostStore;
+        _feedDataSource = [[HNFeedDataSource alloc] initWithTableView:self.tableView readPostStore:nil];
+    }
+
+    return self;
+}
+
+- (void)setPosts:(NSArray *)posts {
+    self.feedDataSource.posts = posts;
+    [self.tableView reloadData];
+}
+
+#pragma mark - Actions
+
+- (void)didSelectPostAtIndexPath:(NSIndexPath *)indexPath {
+    HNPost *post = self.feedDataSource.posts[(NSUInteger) indexPath.row];
+    [self.readPostStore readPK:post.pk];
+    [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+
+    UIViewController *controller = viewControllerForPost(post);
+    [self.originalController hn_showDetailViewControllerWithFallback:controller];
+}
+
+- (void)didSelectPostCommentAtIndexPath:(NSIndexPath *)indexPath {
+    HNPost *post = self.feedDataSource.posts[(NSUInteger) indexPath.row];
+    HNCommentViewController *commentController = [[HNCommentViewController alloc] initWithPostID:post.pk];
+    [self.originalController hn_showDetailViewControllerWithFallback:commentController];
+}
+
+#pragma mark - UITableViewDataSource
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    return self.feedDataSource.posts.count;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    HNPostCell *cell = [self.feedDataSource cellForPostAtIndexPath:indexPath];
+    cell.delegate = self;
+
+    return cell;
+}
+
+#pragma mark - UITableViewDelegate
+
+- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
+    return [self.feedDataSource heightForPostAtIndexPath:indexPath];
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+    [self didSelectPostAtIndexPath:indexPath];
+}
+
+#pragma mark - HNPostCellDelegate
+
+- (void)postCellDidTapCommentButton:(HNPostCell *)postCell {
+    NSIndexPath *indexPath = [self.tableView indexPathForCell:postCell];
+    [self didSelectPostCommentAtIndexPath:indexPath];
+}
+
+@end


### PR DESCRIPTION
Hey, @rnystrom !

#### Summary:
- Migrate to UISearchController
- Due to this [issue](https://stackoverflow.com/questions/45798923/ios-11-search-bar-jumping-to-top-of-screen) on iOS 11.0, use the new way to show search bar

Closes #21.

On iOS 11.0 and later looks likes this:

![simulator screen shot - iphone se - 2018-01-08 at 15 17 27](https://user-images.githubusercontent.com/8586063/34670527-c1b394ea-f487-11e7-96ea-c000bf82db49.png)

  Thanks!